### PR TITLE
hero image slider

### DIFF
--- a/src/Components/HeroImageSlider/HeroImageSlider.css
+++ b/src/Components/HeroImageSlider/HeroImageSlider.css
@@ -1,0 +1,4 @@
+.slider-div{
+  height: 500px;
+  width: 100%;
+}

--- a/src/Components/HeroImageSlider/HeroImageSlider.js
+++ b/src/Components/HeroImageSlider/HeroImageSlider.js
@@ -1,0 +1,43 @@
+import './HeroImageSlider.css'
+import React, {useState, useEffect} from 'react'
+import { useSelector } from 'react-redux';
+import { LoadingIcon } from '../LoadingIcon/LoadingIcon';
+import { Error } from '../Error/Error';
+
+export const HeroImageSlider = () => {
+
+  const slideIds = [97, 143, 91, 66, 9, 28, 84, 121, 137, 76, 103, 100]
+  const slides = useSelector((state) => state.root.discoveredWorlds.filter((world) => {
+    return slideIds.includes(world.id)    
+  }))
+  const [currentSlide, setCurrentSlide] = useState(0)
+  const error = useSelector((state) => state.root.error);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if(currentSlide === 11) {
+        setCurrentSlide(0)
+      } else {
+        setCurrentSlide(currentSlide+1)
+      }
+    }, 4000)
+    return ()=> clearTimeout(timer)
+  }, [currentSlide])
+  
+  if (slides.length === 0) {
+    return <LoadingIcon />
+  } else if (error) {
+    return <Error />
+  } else if (slides.length > 0) {
+    const heroImageStyle = {
+      backgroundImage: `url(${slides[currentSlide].img.landscape})`
+    }
+    return (
+      <div className='slider-container'>
+        <div className='slider-div' style={heroImageStyle}>
+        <h1>HYPERLOOM LOGO</h1>
+        </div>
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
# PR Template

HeroImageSlider is ready to be imported and rendered in app component. for now it is just a component that exists, but isn't being rendered anywhere

- [] I have ran all tests (if applicable) and they are passing. 
(Haven't adjusted cypress tests. Will get to that once we've figured out the video)

### Types of changes made?

- [x]  javascript
- [x]  functionality

### What does this PR do?

- Adds functionality for hero image slideshow
- Updates JS for heroImageSlider component

### Relevant Tickets?

- Partially finishes iteration or ticket for [Welcome Page](https://github.com/The-Never-Ending-Story/front-end/issues/40) 

### Questions/Comments/Relevant Screenshots?
As images change, there is a split second where the image is loading and the background image/color will be visible. This is something we discussed in standup earlier and might be an issue that could be fixed with locally stored images or something that BE can address. Something to keep in mind. I also did not include the explore worlds/view random world in the hero image slideshow since I think we determined it would be in the about section? If we decide we do want those clickable links in the hero image carousel, they can be added easily.
